### PR TITLE
Preserve original error instance

### DIFF
--- a/addon/src/-private/better-errors.js
+++ b/addon/src/-private/better-errors.js
@@ -24,7 +24,8 @@ export function throwBetterError(node, key, error, { selector } = {}) {
 
   const wrapperError = new PageObjectError(message, {
     cause: {
-      message: error.cause ? error.cause.toString() : message,
+      message,
+      error: error.cause,
       key,
       node,
       selector,

--- a/addon/src/properties/visitable.js
+++ b/addon/src/properties/visitable.js
@@ -127,7 +127,9 @@ function appendQueryParams(path, queryParams) {
  * @param {string} path - Full path of the route to visit
  * @return {Descriptor}
  *
- * @throws Will throw an error if dynamic segments are not filled
+ * @throws Will throw an error if dynamic segments are not filled.
+ *         Note: An error instance may contain a `cause.error` property
+ *         with the original error thrown by an underlying test helper.
  */
 export function visitable(path) {
   return action(function (dynamicSegmentsAndQueryParams = {}) {

--- a/test-app/tests/unit/-private/properties/visitable-test.ts
+++ b/test-app/tests/unit/-private/properties/visitable-test.ts
@@ -114,10 +114,15 @@ PageObject: 'page.foo("[object Object]")'
   Selector: '.scope'`
       );
 
-      assert.strictEqual(
-        (e as any).cause.message,
-        'UnrecognizedURLError: /non-existing-url/value'
+      const originalError = (e as any).cause.error;
+      assert.true(
+        originalError instanceof Error,
+        '`cause.error` is an instance of `Error`'
       );
+
+      assert.strictEqual(originalError.name, 'UnrecognizedURLError');
+
+      assert.strictEqual(originalError.message, '/non-existing-url/value');
     }
   });
 });


### PR DESCRIPTION
This in attempt to improve the https://github.com/san650/ember-cli-page-object/pull/640 slightly. Feel free to accept or decline it. I think I'm in general fine to merge your PR as is.

---

This adds the `cause.error` which is supposed to keep the original error instance. So consumers may use it as 
```js
  ...
} catch (e) {
  assert.true(e.cause.error instanceof Error)
}
``` 
this is probably not the most elegant solution, but looks good enough to me for this rare(maybe I am wrong) usage scenario.